### PR TITLE
Name the asset as a bundle for caching purposes

### DIFF
--- a/DynamicBundles/DynamicBundles/BundleHelper.cs
+++ b/DynamicBundles/DynamicBundles/BundleHelper.cs
@@ -46,7 +46,7 @@ namespace DynamicBundles
                     string[] dedupedFileRootRelativePaths = filePathsList.Distinct().Reverse().ToArray();
 
                     string listHashCode = StringListHelper.HashCodeForList(dedupedFileRootRelativePaths);
-                    string bundleName = "~/" + listHashCode;
+                    string bundleName = "~/bundle/" + listHashCode;
 
                     if (!bundles.Exists(bundleName))
                     {


### PR DESCRIPTION
I like what you have done with DynamicBundles and am planning on using it in a project; good work.

I thought an enhancement would be to add /bundle/ to the path.  The reason is so response headers on _/bundle/_ can be added to enable browser caching resulting in faster page load time.  I tested this by adding cache control rules in IIS on the _/bundle/_ path and was pleased with the result.

Let me know your thoughts.

Thank you,
Stuart
